### PR TITLE
Include delimiter information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 Friendly names generator inspired by [moby's](https://github.com/moby/moby/tree/master/pkg/namesgenerator) work.
 
+Function signature:
+```
+func Generate(delimiter string) string
+```
+
+Example usage:
 ```
 import "github.com/cip8/autoname"
 
-fmt.Println(autoname.Generate())
+fmt.Println(autoname.Generate("-"))
 ```


### PR DESCRIPTION
I included the function signature to document what the string is, alternatively could do something like very verbosely declare the delimiter to make it clear what the string being passed in, like in [this example](https://play.golang.com/p/GJSsOD8TTvG)